### PR TITLE
Make IP Multiplexing optional

### DIFF
--- a/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
+++ b/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
@@ -155,5 +155,30 @@ return network.registerProtocol('quectel', {
 		o.placeholder = '0';
 		o.datatype = 'uinteger';
 		o.depends('defaultroute', '1');
+
+        o = s.taboption('advanced', form.DynamicList, 'cell_lock_4g', _('4G Cell ID Lock'));
+        o.datatype = 'string';
+        o.placeholder = _('<PCI>,<EARFCN>');
+
+		o.validate = function(section_id, value) {
+            if (value === null || value === '')
+                return true;
+
+            var parts = value.split(',');
+            if (parts.length !== 2)
+                return _('Must be two values separated by a comma(,)');
+
+            var isUnsignedInteger = function(str) {
+                return /^\d+$/.test(str);
+            };
+            
+            if (!isUnsignedInteger(parts[0]))
+                return _('Invalid PCI!');
+            
+            if (!isUnsignedInteger(parts[1]))
+                return _('Invalid EARFCN!');
+
+            return true;
+        };
 	}
 });

--- a/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
+++ b/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
@@ -65,6 +65,9 @@ return network.registerProtocol('quectel', {
 			}, this));
 		};
 
+		o = s.taboption('general', form.Flag, 'multiplexing', _('Use IP Multiplexing'));
+		o.default = o.disabled;
+
 		apn = s.taboption('general', form.Value, 'apn', _('APN'));
 		apn.depends('pdptype', 'ipv4v6');
 		apn.depends('pdptype', 'ipv4');
@@ -79,8 +82,8 @@ return network.registerProtocol('quectel', {
 		};
 
         apnv6 = s.taboption('general', form.Value, 'apnv6', _('IPv6 APN'));
-        apnv6.depends('pdptype', 'ipv4v6');
-		apnv6.depends('pdptype', 'ipv6');
+        apnv6.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
+        apnv6.depends({ pdptype: 'ipv6', multiplexing: '1' });
 		apnv6.validate = function(section_id, value) {
 			if (value == null || value == '')
 				return true;
@@ -127,17 +130,15 @@ return network.registerProtocol('quectel', {
 		o.datatype    = 'max(9200)';
 
 		o = s.taboption('advanced', form.Value, 'pdnindex', _('PDN index'));
-		o.depends('pdptype', 'ipv4v6');
-		o.depends('pdptype', 'ipv4');
+		o.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
+        o.depends({ pdptype: 'ipv4', multiplexing: '1' });
 		o.placeholder = '1';
-		o.default = 1;
 		o.datatype = 'and(uinteger,min(1),max(7))';
 
 		o = s.taboption('advanced', form.Value, 'pdnindexv6', _('IPv6 PDN index'));
-		o.depends('pdptype', 'ipv4v6');
-		o.depends('pdptype', 'ipv6');
+		o.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
+        o.depends({ pdptype: 'ipv6', multiplexing: '1' });
 		o.placeholder = '2';
-		o.default = 2;
 		o.datatype = 'and(uinteger,min(1),max(7))';
 
 		o = s.taboption('general', form.ListValue, 'pdptype', _('PDP Type'));

--- a/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
+++ b/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
@@ -81,9 +81,9 @@ return network.registerProtocol('quectel', {
 			return true;
 		};
 
-        apnv6 = s.taboption('general', form.Value, 'apnv6', _('IPv6 APN'));
-        apnv6.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
-        apnv6.depends({ pdptype: 'ipv6', multiplexing: '1' });
+		apnv6 = s.taboption('general', form.Value, 'apnv6', _('IPv6 APN'));
+		apnv6.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
+		apnv6.depends({ pdptype: 'ipv6', multiplexing: '1' });
 		apnv6.validate = function(section_id, value) {
 			if (value == null || value == '')
 				return true;
@@ -131,13 +131,13 @@ return network.registerProtocol('quectel', {
 
 		o = s.taboption('advanced', form.Value, 'pdnindex', _('PDN index'));
 		o.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
-        o.depends({ pdptype: 'ipv4', multiplexing: '1' });
+		o.depends({ pdptype: 'ipv4', multiplexing: '1' });
 		o.placeholder = '1';
 		o.datatype = 'and(uinteger,min(1),max(7))';
 
 		o = s.taboption('advanced', form.Value, 'pdnindexv6', _('IPv6 PDN index'));
 		o.depends({ pdptype: 'ipv4v6', multiplexing: '1' });
-        o.depends({ pdptype: 'ipv6', multiplexing: '1' });
+		o.depends({ pdptype: 'ipv6', multiplexing: '1' });
 		o.placeholder = '2';
 		o.datatype = 'and(uinteger,min(1),max(7))';
 


### PR DESCRIPTION
Added new config "Use IP Multiplexing" to control if dual stack IP will be obtained via QMAP IP Multiplexing or via PDP Type IPV4V6

**With IP Multiplexing Enabled**
![image](https://github.com/user-attachments/assets/f5898591-537e-42f3-bf2c-2ee5f12c3720)
![image](https://github.com/user-attachments/assets/fba3ef41-c7cd-4905-824d-e719065371bc)

**With IP Multiplexing Disabled**
![image](https://github.com/user-attachments/assets/20ba10fc-2be3-4b16-8ddb-a96c3a45f91e)
![image](https://github.com/user-attachments/assets/4992c8e0-d6d2-4b19-9a64-886ea9e788d5)


