### PR TITLE
quectel-cm improvements

### DIFF
--- a/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
+++ b/wwan/app/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
@@ -71,6 +71,7 @@ return network.registerProtocol('quectel', {
 		apn = s.taboption('general', form.Value, 'apn', _('APN'));
 		apn.depends('pdptype', 'ipv4v6');
 		apn.depends('pdptype', 'ipv4');
+		apn.depends({pdptype: 'ipv6', multiplexing: '0'});
 		apn.validate = function(section_id, value) {
 			if (value == null || value == '')
 				return true;
@@ -140,6 +141,9 @@ return network.registerProtocol('quectel', {
 		o.depends({ pdptype: 'ipv6', multiplexing: '1' });
 		o.placeholder = '2';
 		o.datatype = 'and(uinteger,min(1),max(7))';
+
+		o = s.taboption('advanced', form.Flag, 'create_virtual_interface', _('Auto-create virtual interface'));
+		o.default = o.enabled;
 
 		o = s.taboption('general', form.ListValue, 'pdptype', _('PDP Type'));
 		o.value('ipv4v6', 'IPv4/IPv6');

--- a/wwan/app/quectel-cm/files/quectel.sh
+++ b/wwan/app/quectel-cm/files/quectel.sh
@@ -108,13 +108,13 @@ proto_quectel_setup() {
 		[ -n "$pdnindexv6" ] || pdnindexv6="2"
 
 		if [ -n "$ipv4opt" ]; then
-			quectel-cm -i "$ifname" $ipv4opt -n $pdnindex -m 1 ${pincode:+-p $pincode} -s "$apn" "$username" "$password" "$auth" &
+			quectel-cm -o -i "$ifname" $ipv4opt -n $pdnindex -m 1 ${pincode:+-p $pincode} -s "$apn" "$username" "$password" "$auth" &
 		fi
 		if [ -n "$ipv6opt" ]; then
-			quectel-cm -i "$ifname" $ipv6opt -n $pdnindexv6 -m 2 ${pincode:+-p $pincode} -s "$apnv6" "$username" "$password" "$auth" &
+			quectel-cm -o -i "$ifname" $ipv6opt -n $pdnindexv6 -m 2 ${pincode:+-p $pincode} -s "$apnv6" "$username" "$password" "$auth" &
 		fi
 	else
-		quectel-cm -i "$ifname" $ipv4opt $ipv6opt ${pincode:+-p $pincode} -s "$apn" "$username" "$password" "$auth" &
+		quectel-cm -o -i "$ifname" $ipv4opt $ipv6opt ${pincode:+-p $pincode} -s "$apn" "$username" "$password" "$auth" &
 	fi
 	
 	sleep 5

--- a/wwan/app/quectel-cm/src/QMIThread.h
+++ b/wwan/app/quectel-cm/src/QMIThread.h
@@ -202,6 +202,7 @@ typedef struct __PROFILE {
     bool enable_ipv4;
     bool enable_ipv6;
     bool no_dhcp;
+    bool openwrt_mode;
     const char *logfile;
     const char *usblogfile;
     char expect_adapter[32];

--- a/wwan/app/quectel-cm/src/main.c
+++ b/wwan/app/quectel-cm/src/main.c
@@ -251,6 +251,7 @@ static int usage(const char *progname) {
     dbg_time("-b                                     Enable network interface bridge function (default 0)");
     dbg_time("-v                                     Verbose log mode, for debug purpose.");
     dbg_time("-d                                     Obtain the IP address and dns through qmi");
+    dbg_time("-o                                     Let OpenWrt obtain the IP address via DHCP");
     dbg_time("[Examples]");
     dbg_time("Example 1: %s ", progname);
     dbg_time("Example 2: %s -s 3gnet ", progname);
@@ -885,6 +886,10 @@ static int parse_user_input(int argc, char **argv, PROFILE_T *profile) {
 
             case 'd':
                 profile->no_dhcp = 1;
+            break;
+
+            case 'o':
+                profile->openwrt_mode = 1;
             break;
 
             case 'u':


### PR DESCRIPTION
**Changelogs**:

1. Fixed issue where IPv6 APN field is missing when Multiplexing is disabled and PDP type is IPv6
2. Added option to skip creating virtual DHCP interfaces in the quectel proto script
3. Added option `-o` in `quectel-cm` to let OpenWrt obtain IP address
4. Fixed incorrect entries in `resolve.conf` caused by `quectel-cm`